### PR TITLE
Fixed missing values in callback args

### DIFF
--- a/openzwave.pyx
+++ b/openzwave.pyx
@@ -311,9 +311,9 @@ cdef void callback(const_notification _notification, void* _context) with gil:
          'homeId' : notification.GetHomeId(),
          'nodeId' : notification.GetNodeId(),
          }
-    if n['notificationType'] == Type_Group:
+    if notification.GetType() == Type_Group:
         n['groupIdx'] = notification.GetGroupIdx()
-    if n['notificationType'] == Type_NodeEvent:
+    if notification.GetType() == Type_NodeEvent:
         n['event'] = notification.GetEvent()
 
     addValueId(notification.GetValueID(), n)


### PR DESCRIPTION
I found the "event" key was missing from the callback dictionary for NodeEvents and tracked it down to this comparison (see diff) which seemed to be comparing an int to a string.
